### PR TITLE
Fix Issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,14 @@ const struct ArgumentDefinition argdefs[] = {
 This means the program accepts a total of 2 arguments, but will exit if a value for the 'positional-arg' is not provided. Please refer to the [ArgumentDefinition Specs]() for more information on the fields of this structure and how they are used.
 
 ### Parsing Arguments
-No you are ready to parse arguments! All which is required is initializing a table into which the arguments and their values can be stored and calling the 'parse_args()' function. Below if a sample main program to demonstrate how to initialize your program and parse the arguments:
+Now you are ready to parse arguments! All which is required is calling the 'parse_args()' function. Below if a sample main program to demonstrate how to initialize your program and parse the arguments:
 ```c
 int main(int argc, char** argv)
 {
     int parse_res = BARGP_SUCCESS;
-    struct VTable vtable = { 0 };
 
 
-    parse_res = parse_args(&vtable, argc, (const char**)(argv), argdefs);
+    parse_res = parse_args(argc, (const char**)(argv), argdefs);
     if (parse_res != BARGP_SUCCESS)
     {
         fprintf(stderr, "Parsing failed: %d\n", parse_res);
@@ -105,7 +104,7 @@ int main(int argc, char** argv)
     }
 
 exit:
-    vtable_destroy(&vtable);
+    vtable_destroy();
 
     return parse_res;
 }

--- a/examples/ppm.c
+++ b/examples/ppm.c
@@ -78,13 +78,12 @@ int main(int argc, char** argv)
     size_t buf_size = 0;
     int parse_res = BARGP_SUCCESS;
     struct Arguments args = { 0 };
-    struct VTable vtable = { 0 };
     struct Rect* rect = NULL;
 
 
     args.bg_color = 0;
 
-    parse_res = parse_args(&vtable, argc, (const char**)(argv), argdefs);
+    parse_res = parse_args(argc, (const char**)(argv), argdefs);
     if (parse_res != BARGP_SUCCESS)
     {
         fprintf(stderr, "Parsing failed: %d\n", parse_res);
@@ -92,11 +91,11 @@ int main(int argc, char** argv)
     }
 
 
-    args.out = (char*)get_arg_index(&vtable, 0);
-    args.width = *(size_t*)get_arg_index(&vtable, 1);
-    args.height = *(size_t*)get_arg_index(&vtable, 2);
-    if ((value = get_arg_key(&vtable, 'b')) != NULL) args.bg_color = *(char*)(value);
-    if ((value = get_arg_key(&vtable, 'r')) != NULL)
+    args.out = (char*)get_arg_index(0);
+    args.width = *(size_t*)get_arg_index(1);
+    args.height = *(size_t*)get_arg_index(2);
+    if ((value = get_arg_key('b')) != NULL) args.bg_color = *(char*)(value);
+    if ((value = get_arg_key('r')) != NULL)
     {
         rect = malloc(sizeof(struct Rect));
         rect->pos[0] = ((size_t*)(value))[0];
@@ -132,7 +131,7 @@ int main(int argc, char** argv)
     }
 
 exit:
-    vtable_destroy(&vtable);
+    vtable_destroy();
 
     return parse_res;
 }

--- a/include/bargp.h
+++ b/include/bargp.h
@@ -76,26 +76,25 @@ void count_args(
 );
 
 
-void* get_arg_index(const struct VTable* vtable, const size_t index);
+void* get_arg_index(const size_t index);
 
 
-void* get_arg_key(const struct VTable* vtable, const char key);
+void* get_arg_key(const char key);
 
 
-void* get_arg_name(const struct VTable* vtable, const char* name);
+void* get_arg_name(const char* name);
 
 
-size_t get_hash_key(const struct VTable* vtable, const char key);
+size_t get_hash_key(const char key);
 
 
-size_t get_hash_name(const struct VTable* vtable, const char* argdef);
+size_t get_hash_name(const char* argdef);
 
 
-void help_fmt(const struct VTable* vtable, const struct ArgumentDefinition* argdefs);
+void help_fmt(const struct ArgumentDefinition* argdefs);
 
 
 int parse_args(
-    struct VTable* vtable,
     const int argc,
     const char** argv,
     const struct ArgumentDefinition* argdefs
@@ -103,14 +102,13 @@ int parse_args(
 
 
 void vtable_create(
-    struct VTable* vtable,
     const size_t n_opt_args,
     const size_t n_stat_args,
     const struct ArgumentDefinition* argdefs
 );
 
 
-void vtable_destroy(struct VTable* vtable);
+void vtable_destroy();
 
 
 #endif  /* BARGP_H */


### PR DESCRIPTION
Addresses issue #4 by having a static, global argument table allocated in 'bargp.c'. This allows one table to exist at a given moment, and prevents the user from having to directly interface with the table.