### PR TITLE
Rename ArgTable Funcs

### DIFF
--- a/examples/ppm.c
+++ b/examples/ppm.c
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
     }
 
 exit:
-    argtable_destroy();
+    free_argtable();
 
     return parse_res;
 }

--- a/include/bargp.h
+++ b/include/bargp.h
@@ -101,14 +101,14 @@ int parse_args(
 ); 
 
 
-void argtable_create(
+void init_argtable(
     const size_t n_opt_args,
     const size_t n_stat_args,
     const struct ArgumentDefinition* argdefs
 );
 
 
-void argtable_destroy();
+void free_argtable();
 
 
 #endif  /* BARGP_H */

--- a/src/bargp.c
+++ b/src/bargp.c
@@ -237,7 +237,7 @@ int parse_args(
 
 
     count_args(&n_opt_args, &n_stat_args, argdefs, argv, argc);
-    argtable_create(n_opt_args, n_stat_args, argdefs);
+    init_argtable(n_opt_args, n_stat_args, argdefs);
     if (need_help) help_fmt(argdefs);
 
     for (size_t i = 1; i < argc; i += 1)
@@ -294,7 +294,7 @@ int parse_args(
 }
 
 
-void argtable_create(
+void init_argtable(
         const size_t n_opt_args,
         const size_t n_stat_args,
         const struct ArgumentDefinition* argdefs
@@ -333,7 +333,7 @@ void argtable_create(
 }
 
 
-void argtable_destroy()
+void free_argtable()
 {
     for (size_t i = 0; i < argtable.n_opt_names; i += 1)
     {


### PR DESCRIPTION
Renames the functions for creating and destroying the argument table. Now it is more clear that the argument table gets initialized and the memory allocated gets freed.